### PR TITLE
Add monthly historical rate backfill

### DIFF
--- a/.github/workflows/rate-backfill.yml
+++ b/.github/workflows/rate-backfill.yml
@@ -1,0 +1,73 @@
+name: Monthly historical rate backfill
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Candidate last-day-of-month runs, at 03:00 UTC (after the daily 01:00 job).
+    # The "Only proceed on last day of month" step skips all but the true last day.
+    - cron: "0 3 28-31 * *"
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Only proceed on last day of month
+        id: lastday
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$(date -u -d tomorrow +%d)" = "01" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure jq is installed
+        if: steps.lastday.outputs.run == 'true'
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y jq
+          fi
+
+      - name: Run backfill script
+        if: steps.lastday.outputs.run == 'true'
+        env:
+          TODAY_URL: ${{ secrets.RATE_TODAY_URL }}
+          HISTORICAL_URL: ${{ secrets.RATE_HISTORICAL_URL }}
+        run: |
+          set -euo pipefail
+          chmod +x .scripts/backfill.sh .scripts/fetch.sh || true
+          ./.scripts/backfill.sh "$TODAY_URL" "$HISTORICAL_URL" 60
+
+      - name: Commit and push changes
+        if: steps.lastday.outputs.run == 'true' && github.ref_name == 'main'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to commit."
+          else
+            git add -A
+            # Derive the oldest/newest changed dates under exchange/ for the commit message
+            CHANGED_FILES="$(git status --porcelain | awk '/ exchange\/.*\.json$/ {print $2}' | sort)"
+            OLDEST_FILE="$(echo "$CHANGED_FILES" | head -n1)"
+            NEWEST_FILE="$(echo "$CHANGED_FILES" | tail -n1)"
+            if [ -n "$OLDEST_FILE" ] && [ -n "$NEWEST_FILE" ]; then
+              OY="$(echo "$OLDEST_FILE" | cut -d'/' -f2)"; OM="$(echo "$OLDEST_FILE" | cut -d'/' -f3)"; OD="$(basename "$OLDEST_FILE" .json)"
+              NY="$(echo "$NEWEST_FILE" | cut -d'/' -f2)"; NM="$(echo "$NEWEST_FILE" | cut -d'/' -f3)"; ND="$(basename "$NEWEST_FILE" .json)"
+              git commit -m "chore: backfill rates for ${OY}-${OM}-${OD}..${NY}-${NM}-${ND}"
+            else
+              git commit -m "chore: backfill rates"
+            fi
+            git push
+          fi

--- a/.scripts/backfill.sh
+++ b/.scripts/backfill.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Usage: backfill.sh TODAY_URL HISTORICAL_URL [COUNT]
+# Walks backward day-by-day from the oldest existing exchange/ date,
+# fetching COUNT (default 60) additional historical days via fetch.sh.
+# Stops early if a fetch fails (e.g. API exhausted / no data that far back).
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+FETCH_SH="$SCRIPT_DIR/fetch.sh"
+
+usage() {
+  echo "Usage: $0 TODAY_URL HISTORICAL_URL [COUNT]" >&2
+}
+
+die() {
+  echo "$@" >&2
+  exit 1
+}
+
+log() {
+  echo "$@" >&2
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command '$1' not found in PATH"
+}
+
+# Find the oldest existing date under exchange/, echoes YYYY-MM-DD or nothing
+find_oldest_date() {
+  [ -d exchange ] || return 0
+
+  y="$(ls exchange 2>/dev/null | sort | head -n1)"
+  [ -n "$y" ] || return 0
+
+  m="$(ls "exchange/$y" 2>/dev/null | sort | head -n1)"
+  [ -n "$m" ] || return 0
+
+  d_file="$(ls "exchange/$y/$m" 2>/dev/null | sort | head -n1)"
+  [ -n "$d_file" ] || return 0
+
+  d="$(basename "$d_file" .json)"
+  printf "%s-%s-%s" "$y" "$m" "$d"
+}
+
+main() {
+  TODAY_URL="${1:-}"
+  HISTORICAL_URL="${2:-}"
+  COUNT="${3:-60}"
+
+  if [ -z "${TODAY_URL}" ] || [ -z "${HISTORICAL_URL}" ]; then
+    usage
+    exit 1
+  fi
+
+  require_cmd date
+  require_cmd sort
+  require_cmd basename
+  [ -x "$FETCH_SH" ] || require_cmd sh
+
+  oldest="$(find_oldest_date)"
+  if [ -z "$oldest" ]; then
+    log "No existing data found under exchange/. Nothing to backfill from."
+    exit 0
+  fi
+  log "Oldest existing date: $oldest. Backfilling up to $COUNT day(s) before it."
+
+  i=1
+  fetched_any=0
+  while [ "$i" -le "$COUNT" ]; do
+    target_date="$(date -u -d "$oldest -$i day" +%Y-%m-%d)" || die "Failed to compute date $i day(s) before $oldest"
+
+    log "Backfilling $target_date ..."
+    if "$FETCH_SH" "$TODAY_URL" "$HISTORICAL_URL" "$target_date"; then
+      fetched_any=1
+    else
+      log "Fetch failed for $target_date. Stopping backfill (likely no data further back or API exhausted)."
+      break
+    fi
+
+    i=$((i + 1))
+  done
+
+  if [ "$fetched_any" -eq 1 ]; then
+    log "Backfill complete."
+  else
+    log "Backfill made no progress."
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Daily rate-updater uses ~28-31 of the 100 monthly API calls, leaving quota unused.
- New `.scripts/backfill.sh` walks backward day-by-day from the oldest existing `exchange/YYYY/MM/DD.json`, reusing `fetch.sh`'s single-day mode, stopping on first failed fetch.
- New `.github/workflows/rate-backfill.yml` runs on the last day of each month (cron `28-31` + a guard step) and spends up to 60 calls backfilling.

## Test plan
- [ ] Trigger `rate-backfill.yml` via workflow_dispatch on this branch and check logs
- [ ] Confirm it correctly detects oldest date and requests days before it
- [ ] Confirm re-running skips already-fetched days (no wasted calls)
- [ ] Merge to main, verify scheduled run on next month-end